### PR TITLE
Allow host to be used if x-forwarded-host is not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 function absoluteUrl(req, setLocalhost) {
   var protocol = 'https:';
-  var host = req ? req.headers['x-forwarded-host'] : window.location.host;
+  var host = req ? (req.headers['x-forwarded-host'] || req.headers['host']) : window.location.host;
   if (host.indexOf('localhost') > -1) {
     if (setLocalhost) host = setLocalhost;
     protocol = 'http:';


### PR DESCRIPTION
fixes #6 

Untested just freehanded it on the github UI