### PR TITLE
Allow comma-separated values of x-forwarded-proto

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function absoluteUrl(req, localhostAddress) {
     req.headers['x-forwarded-host'] &&
     typeof req.headers['x-forwarded-host'] === 'string'
   ) {
-    host = req.headers['x-forwarded-host']
+    host = req.headers['x-forwarded-host'].split(',')[0]
   }
   if (
     req &&

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function absoluteUrl(req, localhostAddress) {
     : _a.headers)
       ? req.headers.host
       : window.location.host) || localhostAddress
-  var protocol = /^localhost(:\d+)?$/.test(host) ? 'http:' : 'https:'
+  var protocol = isLocalNetwork(host) ? 'http:' : 'https:'
   if (
     req &&
     req.headers['x-forwarded-host'] &&
@@ -31,5 +31,17 @@ function absoluteUrl(req, localhostAddress) {
     host: host,
     origin: protocol + '//' + host,
   }
+}
+function isLocalNetwork(hostname) {
+  if (hostname === void 0) {
+    hostname = window.location.host
+  }
+  return (
+    hostname.startsWith('localhost') ||
+    hostname.startsWith('127.0.0.1') ||
+    hostname.startsWith('192.168.') ||
+    hostname.startsWith('10.0.') ||
+    hostname.endsWith('.local')
+  )
 }
 exports['default'] = absoluteUrl

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function absoluteUrl(req, localhostAddress) {
     req.headers['x-forwarded-proto'] &&
     typeof req.headers['x-forwarded-proto'] === 'string'
   ) {
-    protocol = req.headers['x-forwarded-proto'] + ':'
+    protocol = req.headers['x-forwarded-proto'].split(',')[0] + ':'
   }
   return {
     protocol: protocol,

--- a/index.test.ts
+++ b/index.test.ts
@@ -197,4 +197,22 @@ describe('behind a proxy', () => {
     expect(protocol).toBe('https:')
     expect(host).toBe('localhost:5000')
   })
+
+  test('should use the first value of x-forwarded-host', () => {
+    const req = {
+      headers: {
+        host: 'localhost:41560',
+        'x-forwarded-host': 'localhost:5000,fun-url.com',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-port': '5000',
+        'x-forwarded-for': '::ffff:127.0.0.1',
+      },
+    } as any
+
+    const { protocol, host, origin } = nextAbsoluteUrl(req)
+
+    expect(origin).toBe('https://localhost:5000')
+    expect(protocol).toBe('https:')
+    expect(host).toBe('localhost:5000')
+  })
 })

--- a/index.test.ts
+++ b/index.test.ts
@@ -30,7 +30,7 @@ describe('host is corrupted (is empty somehow)', () => {
     expect(protocol).toBe('http:')
     expect(host).toBe('localhost:9000')
   })
-  
+
   test('only from local network passed in', () => {
     window.location.host = '192.168.88.156:4000'
     const { protocol, host, origin } = nextAbsoluteUrl(
@@ -39,7 +39,7 @@ describe('host is corrupted (is empty somehow)', () => {
     )
     expect(origin).toBe('http://192.168.88.156:4000')
     expect(protocol).toBe('http:')
-    expect(host).toBe('localhost:4000')
+    expect(host).toBe('192.168.88.156:4000')
   })
 
   test('only from 127.0.0.1 passed in', () => {
@@ -50,9 +50,9 @@ describe('host is corrupted (is empty somehow)', () => {
     )
     expect(origin).toBe('http://127.0.0.1:4000')
     expect(protocol).toBe('http:')
-    expect(host).toBe('localhost:4000')
+    expect(host).toBe('127.0.0.1:4000')
   })
-  
+
   test('both arguments are passed in', () => {
     const req = {
       headers: {
@@ -161,7 +161,6 @@ describe('host is localhost', () => {
   })
 })
 
-
 describe('behind a proxy', () => {
   test('should use the x-forwarded headers', () => {
     const req = {
@@ -180,5 +179,4 @@ describe('behind a proxy', () => {
     expect(protocol).toBe('http:')
     expect(host).toBe('localhost:5000')
   })
-
 })

--- a/index.test.ts
+++ b/index.test.ts
@@ -179,4 +179,22 @@ describe('behind a proxy', () => {
     expect(protocol).toBe('http:')
     expect(host).toBe('localhost:5000')
   })
+
+  test('should use the first value of x-forwarded-proto', () => {
+    const req = {
+      headers: {
+        host: 'localhost:41560',
+        'x-forwarded-host': 'localhost:5000',
+        'x-forwarded-proto': 'https, http',
+        'x-forwarded-port': '5000',
+        'x-forwarded-for': '::ffff:127.0.0.1',
+      },
+    } as any
+
+    const { protocol, host, origin } = nextAbsoluteUrl(req)
+
+    expect(origin).toBe('https://localhost:5000')
+    expect(protocol).toBe('https:')
+    expect(host).toBe('localhost:5000')
+  })
 })

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ function absoluteUrl(
     req.headers['x-forwarded-host'] &&
     typeof req.headers['x-forwarded-host'] === 'string'
   ) {
-    host = req.headers['x-forwarded-host']
+    host = req.headers['x-forwarded-host'].split(',')[0]
   }
 
   if (

--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ function absoluteUrl(
     req.headers['x-forwarded-proto'] &&
     typeof req.headers['x-forwarded-proto'] === 'string'
   ) {
-    protocol = `${req.headers['x-forwarded-proto']}:`
+    protocol = `${req.headers['x-forwarded-proto'].split(',')[0]}:`
   }
 
   return {
@@ -32,13 +32,13 @@ function absoluteUrl(
 }
 
 function isLocalNetwork(hostname = window.location.host) {
-    return (
-        hostname.startsWith('localhost') ||
-        hostname.startsWith('127.0.0.1') ||
-        hostname.startsWith('192.168.') ||
-        hostname.startsWith('10.0.') ||
-        hostname.endsWith('.local')
-    );
+  return (
+    hostname.startsWith('localhost') ||
+    hostname.startsWith('127.0.0.1') ||
+    hostname.startsWith('192.168.') ||
+    hostname.startsWith('10.0.') ||
+    hostname.endsWith('.local')
+  )
 }
 
 export default absoluteUrl


### PR DESCRIPTION
There's no formal standard on the "x-forwarded-proto" header, but it isn't always a single value like `http` or `https`: it's sometimes set to a multi-valued list, like `x-forwarded-proto: https,http`. If there are multiple protocols, then the absolutely-constructed URL needs to pick one. Otherwise, it constructs a buggy URL like `"https,http://example.com"`

This PR fixes the `protocol` to use the first listed protocol from the header. I've also fixed some failing tests and rebuild `index.js`, which was out-of-sync. (That file should probably not be source-controlled...)